### PR TITLE
【Fixed】rails gコマンドの際にいらないファイルが生成されないように改善

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,11 +16,15 @@ class UsersController < ApplicationController
   def show
      @user = User.find(params[:id])
   end
+
+  def edit
+    
+  end
 end
 
   private
 
   def user_params
     params.require(:user).permit(:name, :email, :password,
-                                 :password_confirmation)
+                                 :password_confirmation, :image, :image_cache)
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,11 @@ module TaskFriendLink
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
     config.assets.initialize_on_precompile = false
+
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
#1
config/application.rbにhelperとassetsを自動生成しないよう以下を記述

 config.generators do |g|
    g.assets     false
    g.helper     false
 end